### PR TITLE
Migrate to null safety & handle adding to controller in a stable way

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,13 @@ VirtualKeyboardType type
 ```
 ```dart
 // Callback for Key press event. Called with pressed `Key` object.
-Function onKeyPress;
+// will fire before adding pressed key text to controller, if a controller exists
+Function preKeyPress;
+```
+```dart
+// Callback for Key press event. Called with pressed `Key` object.
+// will fire after adding pressed key text to controller, if a controller exists
+Function postKeyPress;
 ```
 ```dart
 // Virtual keyboard height. Default is 300.
@@ -142,7 +148,7 @@ Container(
                 // [A-Z, 0-9]
                 type: VirtualKeyboardType.Alphanumeric,
                 // Callback for key press event
-                onKeyPress: _onKeyPress),
+                postKeyPress: _onKeyPress),
           )
 ```
 
@@ -155,7 +161,7 @@ Container(
                 // [0-9] + .
                 type: VirtualKeyboardType.Numeric,
                 // Callback for key press event
-                onKeyPress: (key) => print(key.text)),
+                postKeyPress: (key) => print(key.text)),
           )
 ```
 
@@ -170,7 +176,7 @@ Container(
                 fontSize: 20,
                 builder: _builder,
                 type: VirtualKeyboardType.Numeric,
-                onKeyPress: _onKeyPress),
+                postKeyPress: _onKeyPress),
           )
 
   /// Builder for keyboard keys.

--- a/example/README.md
+++ b/example/README.md
@@ -75,7 +75,7 @@ class _MyHomePageState extends State<MyHomePage> {
                   type: isNumericMode
                       ? VirtualKeyboardType.Numeric
                       : VirtualKeyboardType.Alphanumeric,
-                  onKeyPress: _onKeyPress),
+                  postKeyPress: _onKeyPress),
             )
           ],
         ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -91,7 +91,7 @@ class _MyHomePageState extends State<MyHomePage> {
                   type: isNumericMode
                       ? VirtualKeyboardType.Numeric
                       : VirtualKeyboardType.Alphanumeric,
-                  onKeyPress: _onKeyPress),
+                  postKeyPress: _onKeyPress),
             )
           ],
         ),

--- a/lib/src/key.dart
+++ b/lib/src/key.dart
@@ -2,13 +2,13 @@ part of virtual_keyboard_multi_language;
 
 /// Virtual Keyboard key
 class VirtualKeyboardKey {
-  String text;
-  String capsText;
+  String? text;
+  String? capsText;
   final VirtualKeyboardKeyType keyType;
-  final VirtualKeyboardKeyAction action;
+  final VirtualKeyboardKeyAction? action;
 
   VirtualKeyboardKey(
-      {this.text, this.capsText, @required this.keyType, this.action}){
+      {this.text, this.capsText, required this.keyType, this.action}){
 
         if(this.text == null && this.action != null){
           this.text = action == VirtualKeyboardKeyAction.Space ? ' ' : (action == VirtualKeyboardKeyAction.Return ? '\n' : '');

--- a/lib/src/keyboard.dart
+++ b/lib/src/keyboard.dart
@@ -25,10 +25,10 @@ class VirtualKeyboard extends StatefulWidget {
 
   /// Font size for keyboard keys.
   final double fontSize;
-   
+
   /// the custom layout for multi or single language
   final VirtualKeyboardLayoutKeys? customLayoutKeys;
-  
+
   /// the text controller go get the output and send the default input
   final TextEditingController? textController;
 
@@ -71,7 +71,7 @@ class VirtualKeyboard extends StatefulWidget {
 class _VirtualKeyboardState extends State<VirtualKeyboard> {
   VirtualKeyboardType type = VirtualKeyboardType.Alphanumeric;
   Function(VirtualKeyboardKey key)? onKeyPress;
-  TextEditingController textController = TextEditingController();
+  late TextEditingController textController;
   // The builder function will be called for each Key object.
   Widget Function(BuildContext context, VirtualKeyboardKey key)? builder;
   late double height;
@@ -145,7 +145,7 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
   @override
   void initState() {
     super.initState();
-    
+
     textController = widget.textController ?? TextEditingController();
     width = widget.width;
     type = widget.type;
@@ -236,7 +236,7 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
             });
 
       if(this.reverseLayout)
-        items = items.reversed.toList();      
+        items = items.reversed.toList();
       return Material(
         color: Colors.transparent,
         child: Row(
@@ -326,7 +326,7 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
         actionKey = GestureDetector(
             onTap: () {
               setState(() {
-                customLayoutKeys.switchLanguage();                
+                customLayoutKeys.switchLanguage();
               });
             },
             child: Container(

--- a/lib/src/keyboard.dart
+++ b/lib/src/keyboard.dart
@@ -12,7 +12,7 @@ class VirtualKeyboard extends StatefulWidget {
   final VirtualKeyboardType type;
 
   /// Callback for Key press event. Called with pressed `Key` object.
-  final Function? onKeyPress;
+  final Function(VirtualKeyboardKey key)? onKeyPress;
 
   /// Virtual keyboard height. Default is 300
   final double height;
@@ -70,7 +70,7 @@ class VirtualKeyboard extends StatefulWidget {
 /// Holds the state for Virtual Keyboard class.
 class _VirtualKeyboardState extends State<VirtualKeyboard> {
   VirtualKeyboardType type = VirtualKeyboardType.Alphanumeric;
-  Function? onKeyPress;
+  Function(VirtualKeyboardKey key)? onKeyPress;
   TextEditingController textController = TextEditingController();
   // The builder function will be called for each Key object.
   Widget Function(BuildContext context, VirtualKeyboardKey key)? builder;

--- a/lib/src/keyboard.dart
+++ b/lib/src/keyboard.dart
@@ -121,15 +121,15 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
       final text = textController!.text;
       final textSelection = textController!.selection;
       final newText = text.replaceRange(
-        textSelection.start,
-        textSelection.end,
+        (textSelection.start >= 0) ? textSelection.start : 0,
+        (textSelection.end >= 0) ? textSelection.end : 0,
         myText,
       );
       final myTextLength = myText.length;
       textController!.text = newText;
       textController!.selection = textSelection.copyWith(
-        baseOffset: textSelection.start + myTextLength,
-        extentOffset: textSelection.start + myTextLength,
+        baseOffset:min(textSelection.start + myTextLength, textController!.text.length),
+        extentOffset:min(textSelection.start + myTextLength, textController!.text.length),
       );
     }
   }

--- a/lib/src/keyboard.dart
+++ b/lib/src/keyboard.dart
@@ -12,7 +12,12 @@ class VirtualKeyboard extends StatefulWidget {
   final VirtualKeyboardType type;
 
   /// Callback for Key press event. Called with pressed `Key` object.
-  final Function(VirtualKeyboardKey key)? onKeyPress;
+  /// will fire before adding key's text to controller if a controller is provided
+  final Function(VirtualKeyboardKey key)? preKeyPress;
+
+  /// Callback for Key press event. Called with pressed `Key` object.
+  /// will fire after adding key's text to controller if a controller is provided
+  final Function(VirtualKeyboardKey key)? postKeyPress;
 
   /// Virtual keyboard height. Default is 300
   final double height;
@@ -48,7 +53,8 @@ class VirtualKeyboard extends StatefulWidget {
   VirtualKeyboard(
       {Key? key,
       required this.type,
-      this.onKeyPress,
+      this.preKeyPress,
+      this.postKeyPress,
       this.builder,
       this.width,
       this.defaultLayouts,
@@ -70,7 +76,8 @@ class VirtualKeyboard extends StatefulWidget {
 /// Holds the state for Virtual Keyboard class.
 class _VirtualKeyboardState extends State<VirtualKeyboard> {
   VirtualKeyboardType type = VirtualKeyboardType.Alphanumeric;
-  Function(VirtualKeyboardKey key)? onKeyPress;
+  Function(VirtualKeyboardKey key)? preKeyPress;
+  Function(VirtualKeyboardKey key)? postKeyPress;
   TextEditingController? textController;
 
   // The builder function will be called for each Key object.
@@ -90,6 +97,8 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
   bool isShiftEnabled = false;
 
   void _onKeyPress(VirtualKeyboardKey key) {
+    if (preKeyPress != null) preKeyPress!(key);
+
     if (key.keyType == VirtualKeyboardKeyType.String) {
       if (isShiftEnabled) {
         _insertText(key.capsText!);
@@ -113,7 +122,7 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
       }
     }
 
-    if (onKeyPress != null) onKeyPress!(key);
+    if (postKeyPress != null) postKeyPress!(key);
   }
 
   void _insertText(String myText) {
@@ -128,8 +137,10 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
       final myTextLength = myText.length;
       textController!.text = newText;
       textController!.selection = textSelection.copyWith(
-        baseOffset:min(textSelection.start + myTextLength, textController!.text.length),
-        extentOffset:min(textSelection.start + myTextLength, textController!.text.length),
+        baseOffset: min(
+            textSelection.start + myTextLength, textController!.text.length),
+        extentOffset: min(
+            textSelection.start + myTextLength, textController!.text.length),
       );
     }
   }
@@ -187,7 +198,8 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
     super.didUpdateWidget(oldWidget);
     setState(() {
       type = widget.type;
-      onKeyPress = widget.onKeyPress;
+      preKeyPress = widget.preKeyPress;
+      postKeyPress = widget.postKeyPress;
       height = widget.height;
       width = widget.width;
       textColor = widget.textColor;
@@ -214,7 +226,8 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
     customLayoutKeys = widget.customLayoutKeys ??
         VirtualKeyboardDefaultLayoutKeys(
             widget.defaultLayouts ?? [VirtualKeyboardDefaultLayouts.English]);
-    onKeyPress = widget.onKeyPress;
+    preKeyPress = widget.preKeyPress;
+    postKeyPress = widget.postKeyPress;
     height = widget.height;
     textColor = widget.textColor;
     fontSize = widget.fontSize;

--- a/lib/src/keyboard.dart
+++ b/lib/src/keyboard.dart
@@ -432,8 +432,7 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
     );
 
     if (key.action == VirtualKeyboardKeyAction.Space)
-      return SizedBox(
-          width: (width ?? MediaQuery.of(context).size.width) / 2, child: wdgt);
+      return Expanded(flex: 6, child: wdgt);
     else
       return Expanded(child: wdgt);
   }

--- a/lib/src/keyboard.dart
+++ b/lib/src/keyboard.dart
@@ -12,13 +12,13 @@ class VirtualKeyboard extends StatefulWidget {
   final VirtualKeyboardType type;
 
   /// Callback for Key press event. Called with pressed `Key` object.
-  final Function onKeyPress;
+  final Function? onKeyPress;
 
   /// Virtual keyboard height. Default is 300
   final double height;
 
   /// Virtual keyboard height. Default is full screen width
-  final double width;
+  final double? width;
 
   /// Color for key texts and icons.
   final Color textColor;
@@ -27,13 +27,13 @@ class VirtualKeyboard extends StatefulWidget {
   final double fontSize;
    
   /// the custom layout for multi or single language
-  final VirtualKeyboardLayoutKeys customLayoutKeys;
+  final VirtualKeyboardLayoutKeys? customLayoutKeys;
   
   /// the text controller go get the output and send the default input
-  final TextEditingController textController;
+  final TextEditingController? textController;
 
   /// The builder function will be called for each Key object.
-  final Widget Function(BuildContext context, VirtualKeyboardKey key) builder;
+  final Widget Function(BuildContext context, VirtualKeyboardKey key)? builder;
 
   /// Set to true if you want only to show Caps letters.
   final bool alwaysCaps;
@@ -43,11 +43,11 @@ class VirtualKeyboard extends StatefulWidget {
 
   /// used for multi-languages with default layouts, the default is English only
   /// will be ignored if customLayoutKeys is not null
-  final List<VirtualKeyboardDefaultLayouts> defaultLayouts;
+  final List<VirtualKeyboardDefaultLayouts>? defaultLayouts;
 
   VirtualKeyboard(
-      {Key key,
-      @required this.type,
+      {Key? key,
+      required this.type,
       this.onKeyPress,
       this.builder,
       this.width,
@@ -69,20 +69,20 @@ class VirtualKeyboard extends StatefulWidget {
 
 /// Holds the state for Virtual Keyboard class.
 class _VirtualKeyboardState extends State<VirtualKeyboard> {
-  VirtualKeyboardType type;
-  Function onKeyPress;
-  TextEditingController textController;
+  VirtualKeyboardType type = VirtualKeyboardType.Alphanumeric;
+  Function? onKeyPress;
+  TextEditingController textController = TextEditingController();
   // The builder function will be called for each Key object.
-  Widget Function(BuildContext context, VirtualKeyboardKey key) builder;
-  double height;
-  double width;
-  Color textColor;
-  double fontSize;
-  bool alwaysCaps;
-  bool reverseLayout;
-  VirtualKeyboardLayoutKeys customLayoutKeys;
+  Widget Function(BuildContext context, VirtualKeyboardKey key)? builder;
+  late double height;
+  double? width;
+  late Color textColor;
+  late double fontSize;
+  late bool alwaysCaps;
+  late bool reverseLayout;
+  late VirtualKeyboardLayoutKeys customLayoutKeys;
   // Text Style for keys.
-  TextStyle textStyle;
+  late TextStyle textStyle;
 
   // True if shift is enabled.
   bool isShiftEnabled = false;
@@ -90,7 +90,7 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
   void _onKeyPress(VirtualKeyboardKey key){
 
     if (key.keyType == VirtualKeyboardKeyType.String) {
-      textController.text += (isShiftEnabled ? key.capsText : key.text);
+      textController.text += (isShiftEnabled ? key.capsText! : key.text!);
     } else if (key.keyType == VirtualKeyboardKeyType.Action) {
       switch (key.action) {
         case VirtualKeyboardKeyAction.Backspace:
@@ -101,7 +101,7 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
           textController.text += '\n';
           break;
         case VirtualKeyboardKeyAction.Space:
-          textController.text += key.text;
+          textController.text += key.text!;
           break;
         case VirtualKeyboardKeyAction.Shift:
           break;
@@ -110,18 +110,18 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
     }
 
     if(onKeyPress != null)
-      onKeyPress(key);
+      onKeyPress!(key);
 
   }
 
   @override dispose(){
     if(widget.textController == null) // dispose if created locally only
-      textController?.dispose();
+      textController.dispose();
     super.dispose();
   }
 
   @override
-  void didUpdateWidget(Widget oldWidget) {
+  void didUpdateWidget(VirtualKeyboard oldWidget) {
     super.didUpdateWidget(oldWidget);
     setState(() {
       type = widget.type;
@@ -131,7 +131,7 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
       textColor = widget.textColor;
       fontSize = widget.fontSize;
       alwaysCaps = widget.alwaysCaps;
-      reverseLayout = widget.reverseLayout ?? false;
+      reverseLayout = widget.reverseLayout;
       textController = widget.textController ?? textController;
       customLayoutKeys = widget.customLayoutKeys ?? customLayoutKeys ;
       // Init the Text Style for keys.
@@ -155,7 +155,7 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
     textColor = widget.textColor;
     fontSize = widget.fontSize;
     alwaysCaps = widget.alwaysCaps;
-    reverseLayout = widget.reverseLayout ?? false;
+    reverseLayout = widget.reverseLayout;
     // Init the Text Style for keys.
     textStyle = TextStyle(
       fontSize: fontSize,
@@ -228,11 +228,8 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
                 }
               } else {
                 // Call the builder function, so the user can specify custom UI for keys.
-                keyWidget = builder(context, virtualKeyboardKey);
+                keyWidget = builder!(context, virtualKeyboardKey);
 
-                if (keyWidget == null) {
-                  throw 'builder function must return Widget';
-                }
               }
 
               return keyWidget;
@@ -255,7 +252,7 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
   }
 
   // True if long press is enabled.
-  bool longPress;
+  bool longPress = false;
 
   /// Creates default UI element for keyboard Key.
   Widget _keyboardDefaultKey(VirtualKeyboardKey key) {
@@ -269,8 +266,8 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
         child: Center(
             child: Text(
           alwaysCaps
-              ? key.capsText
-              : (isShiftEnabled ? key.capsText : key.text),
+              ? key.capsText!
+              : (isShiftEnabled ? key.capsText! : key.text!),
           style: textStyle,
         )),
       ),
@@ -283,7 +280,7 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
     Widget actionKey;
 
     // Switch the action type to build action Key widget.
-    switch (key.action) {
+    switch (key.action!) {
       case VirtualKeyboardKeyAction.Backspace:
         actionKey = GestureDetector(
             onLongPress: () {
@@ -340,7 +337,6 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
                 color: textColor,
               ),
             ));
-        break;
         break;
     }
 

--- a/lib/src/layout_keys.dart
+++ b/lib/src/layout_keys.dart
@@ -107,6 +107,7 @@ const List<List> _defaultEnglishLayout = [
     VirtualKeyboardKeyAction.SwithLanguage,
     '@',
     VirtualKeyboardKeyAction.Space,
+    '-',
     '&',
     '_',
   ]

--- a/lib/virtual_keyboard_multi_language.dart
+++ b/lib/virtual_keyboard_multi_language.dart
@@ -1,6 +1,7 @@
 library virtual_keyboard_multi_language;
 
 import 'dart:async';
+import 'dart:math';
 import 'package:flutter/material.dart';
 
 part './src/key_action.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.2.2
 homepage: https://github.com/ahmed-eg/virtual_keyboard_multi_language
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/test/virtual_keyboard_test.dart
+++ b/test/virtual_keyboard_test.dart
@@ -6,7 +6,7 @@ void main() {
   test('creates keyboard widget with Alphanumeric type', () {
     final keyboard = VirtualKeyboard(
       type: VirtualKeyboardType.Alphanumeric,
-      onKeyPress: (key) => null,
+      postKeyPress: (key) => null,
     );
     expect(keyboard.type, VirtualKeyboardType.Alphanumeric);
   });

--- a/test/virtual_keyboard_test.dart
+++ b/test/virtual_keyboard_test.dart
@@ -6,7 +6,7 @@ void main() {
   test('creates keyboard widget with Alphanumeric type', () {
     final keyboard = VirtualKeyboard(
       type: VirtualKeyboardType.Alphanumeric,
-      onKeyPress: () => null,
+      onKeyPress: (key) => null,
     );
     expect(keyboard.type, VirtualKeyboardType.Alphanumeric);
   });


### PR DESCRIPTION
Migrate to null safety
using just `controller.text=text` make the selection in the controller in the wrong place and only append to the end of the controller without any regard to the place of the cursor

this PR solves this by respecting the place of the cursor and only append or delete from there which is a lot cleaner and expected from the end-user.

please let me know if you have any questions
