### PR TITLE
Fix builder parameter

### DIFF
--- a/lib/src/keyboard.dart
+++ b/lib/src/keyboard.dart
@@ -67,6 +67,7 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
     super.didUpdateWidget(oldWidget);
     setState(() {
       type = widget.type;
+      builder = widget.builder;
       onKeyPress = widget.onKeyPress;
       height = widget.height;
       textColor = widget.textColor;
@@ -86,6 +87,7 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
     super.initState();
 
     type = widget.type;
+    builder = widget.builder;
     onKeyPress = widget.onKeyPress;
     height = widget.height;
     textColor = widget.textColor;


### PR DESCRIPTION
The builder parameter passed to the widget ignored since it's not being copied to the state. This tiny pull request fixes it.



RE: https://github.com/digitalpomegranate/virtual_keyboard/pull/9 