### PR TITLE
Fix builder parameter

### DIFF
--- a/lib/src/keyboard.dart
+++ b/lib/src/keyboard.dart
@@ -124,6 +124,7 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
     super.didUpdateWidget(oldWidget);
     setState(() {
       type = widget.type;
+      builder = widget.builder;
       onKeyPress = widget.onKeyPress;
       height = widget.height;
       width = widget.width;
@@ -151,6 +152,7 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
     customLayoutKeys = widget.customLayoutKeys ??
         VirtualKeyboardDefaultLayoutKeys(
             widget.defaultLayouts ?? [VirtualKeyboardDefaultLayouts.English]);
+    builder = widget.builder;
     onKeyPress = widget.onKeyPress;
     height = widget.height;
     textColor = widget.textColor;


### PR DESCRIPTION
The builder parameter passed to the widget ignored since it's not being copied to the state. This tiny pull request fixes it.

This makes the package way more extensible, by letting people override things within the package without requiring a fork. 
Helping world by probably stopping half the forks that's out there and making this project hopefully easier for you to manage. 

Credits goes to : [@guimei](https://github.com/guimeira)
